### PR TITLE
bump version to 2.4.2.Final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,43 @@
-target
+#Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+release.properties
+.flattened-pom.xml
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/
+
+# IntelliJ
+.idea
+*.ipr
+*.iml
+*.iws
+
+# NetBeans
+nb-configuration.xml
+
+# Visual Studio Code
+.vscode
+.factorypath
+
+# OSX
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# patch
+*.orig
+*.rej
+
+# Local environment
+.env
+
+# Plugin directory
+/.quarkus/cli/plugins/

--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         
         <!-- Apicurio Version -->
-        <apicurio.version>2.3.2-SNAPSHOT</apicurio.version>
-        <apicurio-common-app-components.version>0.1.14.Final</apicurio-common-app-components.version>
+        <apicurio.version>2.4.2.Final</apicurio.version>
+        <apicurio-common-app-components.version>0.2.1.Final</apicurio-common-app-components.version>
 
         <!-- Quarkus Version -->
-        <quarkus.version>2.14.0.Final</quarkus.version>
+        <quarkus.version>2.16.10.Final</quarkus.version>
 
         <version.dependency.plugin>3.3.0</version.dependency.plugin>
+        <version.compiler.plugin>3.11.0</version.compiler.plugin>
     </properties>
 
     <dependencyManagement>
@@ -145,6 +145,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                  <compilerArgs>
+                    <arg>-parameters</arg>
+                  </compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/apicurio/registry/rules/validity/BigqueryContentValidator.java
+++ b/src/main/java/io/apicurio/registry/rules/validity/BigqueryContentValidator.java
@@ -1,10 +1,13 @@
 package io.apicurio.registry.rules.validity;
 
 import io.apicurio.registry.content.ContentHandle;
+import io.apicurio.registry.rest.v2.beans.ArtifactReference;
 import io.apicurio.registry.rules.BigqueryGsonBuilder;
 import io.apicurio.registry.rules.RuleViolationException;
 import io.apicurio.registry.types.RuleType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class BigqueryContentValidator extends BigqueryGsonBuilder implements ContentValidator {
@@ -19,5 +22,11 @@ public class BigqueryContentValidator extends BigqueryGsonBuilder implements Con
             throw new RuleViolationException("invalid big query schema", RuleType.VALIDITY, null, e);
         }
     }
+
+    // @Override
+    // public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references)
+    //         throws RuleViolationException {
+    //     validate(null, artifactContent, Collections.emptyMap());
+    // }
 
 }

--- a/src/main/java/io/apicurio/registry/rules/validity/BigqueryContentValidator.java
+++ b/src/main/java/io/apicurio/registry/rules/validity/BigqueryContentValidator.java
@@ -24,9 +24,9 @@ public class BigqueryContentValidator extends BigqueryGsonBuilder implements Con
     }
 
     // @Override
-    // public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references)
-    //         throws RuleViolationException {
-    //     validate(null, artifactContent, Collections.emptyMap());
-    // }
+    public void validateReferences(ContentHandle artifactContent, List<ArtifactReference> references)
+            throws RuleViolationException {
+        validate(null, artifactContent, Collections.emptyMap());
+    }
 
 }


### PR DESCRIPTION
open points:
- not working with `quarkus:dev`
- not able to update fwd 2.4.3 onwards

details:

## not working with `quarkus:dev`
 
while:
```
mvn clean install
java -jar target/apicurio-registry-with-bigquery-0.0.1-SNAPSHOT-runner.jar 
```

works, if I try:

```
mvn clean quarkus:dev
```

I get:

```
2023-08-30 12:11:00,245 ERROR [io.qua.dep.dev.IsolatedDevModeMain] (main) Failed to start quarkus: java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate threw an exception: javax.enterprise.inject.spi.DeploymentException: javax.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type io.apicurio.common.apps.config.DynamicConfigStorageAccessor and qualifiers [@Default]
	- java member: io.apicurio.common.apps.config.impl.DynamicConfigStartup#configStorageAccessor
	- declared on CLASS bean [types=[io.apicurio.common.apps.config.impl.DynamicConfigStartup, java.lang.Object], qualifiers=[@Default, @Any], target=io.apicurio.common.apps.config.impl.DynamicConfigStartup]
	at io.quarkus.arc.processor.BeanDeployment.processErrors(BeanDeployment.java:1223)
	at io.quarkus.arc.processor.BeanDeployment.init(BeanDeployment.java:288)
	at io.quarkus.arc.processor.BeanProcessor.initialize(BeanProcessor.java:148)
	at io.quarkus.arc.deployment.ArcProcessor.validate(ArcProcessor.java:526)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:281)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
	at java.base/java.lang.Thread.run(Thread.java:833)
	at org.jboss.threads.JBossThread.run(JBossThread.java:501)
Caused by: javax.enterprise.inject.UnsatisfiedResolutionException: Unsatisfied dependency for type io.apicurio.common.apps.config.DynamicConfigStorageAccessor and qualifiers [@Default]
	- java member: io.apicurio.common.apps.config.impl.DynamicConfigStartup#configStorageAccessor
	- declared on CLASS bean [types=[io.apicurio.common.apps.config.impl.DynamicConfigStartup, java.lang.Object], qualifiers=[@Default, @Any], target=io.apicurio.common.apps.config.impl.DynamicConfigStartup]
	at io.quarkus.arc.processor.Beans.resolveInjectionPoint(Beans.java:440)
	at io.quarkus.arc.processor.BeanInfo.init(BeanInfo.java:539)
	at io.quarkus.arc.processor.BeanDeployment.init(BeanDeployment.java:276)
	... 11 more
```


## not able to update fwd 2.4.3 onwards

getting:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.892 s
[INFO] Finished at: 2023-08-30T12:12:42+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:2.16.10.Final:build (default) on project apicurio-registry-with-bigquery: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR] 	[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate threw an exception: javax.enterprise.inject.spi.DeploymentException: Found 34 deployment problems: 
[ERROR] [1] Ambiguous dependencies for type io.apicurio.common.apps.multitenancy.TenantContext and qualifiers [@Default]
[ERROR] 	- java member: io.apicurio.registry.rest.v2.SystemResourceImpl#tctx
[ERROR] 	- declared on CLASS bean [types=[io.apicurio.registry.rest.v2.SystemResource, java.lang.Object, io.apicurio.registry.rest.v2.SystemResourceImpl], qualifiers=[@Default, @Any], target=io.apicurio.registry.rest.v2.SystemResourceImpl]
[ERROR] 	- available beans:
[ERROR] 		- CLASS bean [types=[io.apicurio.common.apps.multitenancy.context.TenantContextImpl, java.lang.Object, io.apicurio.common.apps.multitenancy.TenantContext], qualifiers=[@Default, @Any], target=io.apicurio.common.apps.multitenancy.context.TenantContextImpl]
[ERROR] 		- CLASS bean [types=[io.apicurio.common.apps.multitenancy.context.TenantContextImpl, java.lang.Object, io.apicurio.common.apps.multitenancy.TenantContext], qualifiers=[@Default, @Any], target=io.apicurio.common.apps.multitenancy.context.TenantContextImpl]
```

for about 34 instance.

